### PR TITLE
LibBot and LibTop as standalone stateless entities

### DIFF
--- a/src/Protocol.ts
+++ b/src/Protocol.ts
@@ -105,11 +105,11 @@ export class Protocol extends EventEmitter {
      */
     send(): Buffer {
         if (!this.options.enableOrdering) {
-            const msg = this.tp.send();
+            const msg = this.tp.send()[0];
             this.emit("send", msg);
             return msg;
         }
-        const msg = this.bt.send(this.tp.send());
+        const msg = this.bt.send(this.tp.send()[0]);
         this.emit("send", msg);
         return msg;
     }

--- a/src/__tests__/differ.test.ts
+++ b/src/__tests__/differ.test.ts
@@ -114,16 +114,16 @@ describe("Test differ", () => {
         const obj = {
             int: 1234,
             naprej: {
-              naprej: {
-                float: 3.14,
-              },
-              boolean: false,
+                naprej: {
+                    float: 3.14,
+                },
+                boolean: false,
             },
             bytes: Buffer.from("12345"),
             str: "test",
-        }
-        expect(getDelete(obj, obj)).toEqual({})
-    })
+        };
+        expect(getDelete(obj, obj)).toEqual({});
+    });
 
     test("Start sync with empty object", () => {
         expect(getSync({}, end)).toEqual(end);

--- a/src/__tests__/differ.test.ts
+++ b/src/__tests__/differ.test.ts
@@ -105,9 +105,25 @@ describe("Test differ", () => {
     test("applyDelete", () => {
         expect(applyDelete(start, del)).toEqual(afterDel);
     });
+
     test("applySync", () => {
         expect(applySync(start, sync)).toEqual(afterSync);
     });
+
+    test("Correctly get empty delete with same objects and boolean = false", () => {
+        const obj = {
+            int: 1234,
+            naprej: {
+              naprej: {
+                float: 3.14,
+              },
+              boolean: false,
+            },
+            bytes: Buffer.from("12345"),
+            str: "test",
+        }
+        expect(getDelete(obj, obj)).toEqual({})
+    })
 
     test("Start sync with empty object", () => {
         expect(getSync({}, end)).toEqual(end);

--- a/src/__tests__/libBot.test.ts
+++ b/src/__tests__/libBot.test.ts
@@ -252,4 +252,124 @@ describe("Full cycle", () => {
 
         expect(inputArr).toEqual(outArrOrdered);
     });
+
+    test("Perfect transmission with serialization", () => {
+        let bt1 = new LibBot();
+        let bt2 = new LibBot();
+
+        const outArr: Array<Buffer> = [];
+        const outArrOrdered: Array<Buffer> = [];
+        const inputArr: Array<Buffer> = [];
+        for (let i = 1; i < 20; i++) {
+            const b = Buffer.from([i]);
+            inputArr.push(b);
+            bt1 = new LibBot({ restoreState: bt1.getLibState() });
+            bt2 = new LibBot({ restoreState: bt2.getLibState() });
+            const [, transmissionObj] = bt2.receiveMessage(bt1.send(b));
+            outArr.push(transmissionObj.newMessage);
+            if (transmissionObj.ordered) {
+                transmissionObj.ordered.map((buf) => {
+                    outArrOrdered.push(buf);
+                });
+            }
+        }
+
+        expect(outArr).toEqual(inputArr);
+        expect(outArrOrdered).toEqual(inputArr);
+
+        expect(bt1.maxIncSeq).toEqual(0);
+        expect(bt1.maxEmittedSeq).toEqual(0);
+        expect(bt1.maxSendAck).toEqual(0);
+        expect(bt1.failedReceiveMessageCount).toEqual(0);
+        expect(bt1.failedSendMessageCount).toEqual(0);
+        expect(bt1.maxSendSeq).toEqual(19);
+
+        expect(bt2.maxIncSeq).toEqual(19);
+        expect(bt2.maxEmittedSeq).toEqual(19);
+        expect(bt2.maxSendAck).toEqual(0);
+        expect(bt2.failedReceiveMessageCount).toEqual(0);
+        expect(bt2.failedSendMessageCount).toEqual(0);
+        expect(bt2.maxSendSeq).toEqual(0);
+
+        const bt1a = new LibBot({ restoreState: bt1.getLibState() });
+        const bt2a = new LibBot({ restoreState: bt2.getLibState() });
+
+        expect(bt1a).toEqual(bt1);
+        expect(bt2a).toEqual(bt2);
+    });
+    test("SEQ looping lossy with serialization", () => {
+        let bt1 = new LibBot({
+            autoRetransmit: true,
+        });
+        let bt2 = new LibBot({
+            autoAckOnFailedMessages: 1,
+        });
+
+        const inputArr: Array<Buffer> = [];
+        const outArrOrdered: Array<Buffer> = [];
+
+        let count = 0;
+        for (let i = 1; i <= 205; i++) {
+            const a = Buffer.allocUnsafe(2);
+            a.writeUInt16LE(i);
+            inputArr.push(a);
+            const msg = bt1.send(a);
+            expect(msg[0]).toBeLessThanOrEqual(100);
+
+            count++;
+            if (count % 3 === 0) return;
+            const [messagesToSend, transmissionObj] = bt2.receiveMessage(msg);
+            if (transmissionObj.ordered) {
+                transmissionObj.ordered.map((buf) => {
+                    outArrOrdered.push(buf);
+                });
+            }
+            bt1 = new LibBot({ restoreState: bt1.getLibState() });
+            bt2 = new LibBot({ restoreState: bt2.getLibState() });
+            // eslint-disable-next-line no-loop-func
+            messagesToSend.map((m) => {
+                count++;
+                if (count % 3 === 0) return;
+                bt2.receiveMessage(m);
+            });
+
+            if (bt2.failedReceiveMessageCount > 1) {
+                count++;
+                if (count % 3 === 0) continue;
+                bt2.receiveMessage(bt1.sendAcks());
+                // eslint-disable-next-line no-loop-func
+                bt1.sendFailedMessages().map((m) => {
+                    bt1 = new LibBot({ restoreState: bt1.getLibState() });
+                    bt2 = new LibBot({ restoreState: bt2.getLibState() });
+                    count++;
+                    if (count % 3 === 0) return;
+                    bt2.receiveMessage(m);
+                });
+            }
+        }
+
+        expect(bt1.maxIncSeq).toEqual(0);
+        expect(bt1.maxEmittedSeq).toEqual(0);
+        expect(bt1.maxSendAck).toEqual(0);
+        expect(bt1.failedReceiveMessageCount).toEqual(0);
+        expect(bt1.failedSendMessageCount).toEqual(0);
+        expect(bt1.maxSendSeq).toEqual(206);
+
+        expect(bt2.maxIncSeq).toEqual(206);
+        expect(bt2.maxEmittedSeq).toEqual(206);
+        expect(bt2.maxSendAck).toEqual(0);
+        expect(bt2.failedReceiveMessageCount).toEqual(0);
+        expect(bt2.failedSendMessageCount).toEqual(0);
+        expect(bt2.maxSendSeq).toEqual(0);
+        // @ts-expect-error
+        expect(bt2.recSeqOffset).toEqual(2);
+
+        expect(inputArr).toEqual(outArrOrdered);
+
+        const bt1a = new LibBot({ restoreState: bt1.getLibState() });
+        const bt2a = new LibBot({ restoreState: bt2.getLibState() });
+
+        expect(bt1a).toEqual(bt1);
+        expect(bt2a).toEqual(bt1);
+    });
 });

--- a/src/__tests__/libTop.test.ts
+++ b/src/__tests__/libTop.test.ts
@@ -1,5 +1,5 @@
 import { PbTranscoder } from "../PbTranscoder";
-import LibTop, { ReceiveMessageObject } from "../libTop";
+import LibTop from "../libTop";
 
 const tc = new PbTranscoder({
     protoPath: "./src/__tests__/test.proto",
@@ -10,12 +10,9 @@ describe("Receive message", () => {
 
     beforeEach(() => {
         tp = new LibTop({ transcoder: tc });
-    })
-
-    
+    });
 
     test("Receive message", () => {
-
         const obj = {
             reqRpc: {
                 1: {
@@ -44,53 +41,53 @@ describe("Receive message", () => {
             events: [Buffer.from("123"), Buffer.from("456")],
             eventsOrdered: [Buffer.from("1234"), Buffer.from("5678")],
         };
-    
+
         const expectedResult = {
             events: [Buffer.from("123"), Buffer.from("456")],
             eventsOrdered: [Buffer.from("1234"), Buffer.from("5678")],
             rpcCalls: [
-              {
-                id: 1,
-                method: "sum",
-                args: Buffer.from("1234"),
-              },
-              {
-                id: 2,
-                method: "add",
-              },
-              {
-                id: 3,
-                method: "send",
-                args: Buffer.from("12345"),
-              },
+                {
+                    id: 1,
+                    method: "sum",
+                    args: Buffer.from("1234"),
+                },
+                {
+                    id: 2,
+                    method: "add",
+                },
+                {
+                    id: 3,
+                    method: "send",
+                    args: Buffer.from("12345"),
+                },
             ],
             rpcResults: [
                 {
-                  id: 1,
-                  method: "sum",
-                  args: Buffer.from("1234"),
-                  result: {
-                    returns: Buffer.from("12345"),
-                  },
+                    id: 1,
+                    method: "sum",
+                    args: Buffer.from("1234"),
+                    result: {
+                        returns: Buffer.from("12345"),
+                    },
                 },
                 {
-                  id: 2,
-                  method: "add",
-                  result: {
-                    returns: Buffer.from("123"),
-                    isError: true,
-                  },
+                    id: 2,
+                    method: "add",
+                    result: {
+                        returns: Buffer.from("123"),
+                        isError: true,
+                    },
                 },
-              ],
-          }
+            ],
+        };
         const messageBuf = tc.encode(obj);
 
-        const tp = new LibTop({ transcoder: tc });
+        tp = new LibTop({ transcoder: tc });
 
         expect(tp.callFn("sum", Buffer.from("1234"))).toEqual(1);
         expect(tp.callFnOrdered("add")).toEqual(2);
 
-        tp.send()
+        tp.send();
 
         const ans = tp.receiveMessage(messageBuf);
 
@@ -98,7 +95,6 @@ describe("Receive message", () => {
     });
 
     test("Receive empty message", () => {
-
         expect(tp.receiveMessage(Buffer.allocUnsafe(0))).toEqual({});
         expect(tp.responses.size).toEqual(0);
         expect(tp.requests.size).toEqual(0);
@@ -112,7 +108,7 @@ describe("Sending message", () => {
 
     beforeEach(() => {
         tp = new LibTop({ transcoder: tc });
-    })
+    });
     test("Send regular RPC call", () => {
         tp.callFn("sum", Buffer.from("1234"));
         tp.callFn("add");
@@ -130,7 +126,7 @@ describe("Sending message", () => {
     });
 
     test("Send ordered RPC call", () => {
-        const tp = new LibTop({ transcoder: tc });
+        tp = new LibTop({ transcoder: tc });
         tp.callFnOrdered("sum", Buffer.from("1234"));
         tp.callFnOrdered("add");
         expect(tc.decode(tp.send())).toEqual({
@@ -147,7 +143,7 @@ describe("Sending message", () => {
     });
 
     test("Send regular event", () => {
-        const tp = new LibTop({ transcoder: tc });
+        tp = new LibTop({ transcoder: tc });
         tp.sendEvent(Buffer.from("12"));
         tp.sendEvent(Buffer.from("34"));
 
@@ -156,7 +152,7 @@ describe("Sending message", () => {
         });
     });
     test("Send ordered event", () => {
-        const tp = new LibTop({ transcoder: tc });
+        tp = new LibTop({ transcoder: tc });
         tp.sendEventOrdered(Buffer.from("12"));
         tp.sendEventOrdered(Buffer.from("34"));
 
@@ -172,96 +168,90 @@ describe("LibTop roundtrip", () => {
     beforeEach(() => {
         tp1 = new LibTop({ transcoder: tc });
         tp2 = new LibTop({ transcoder: tc });
-    })
+    });
 
     test("Events", () => {
         tp1.sendEvent(Buffer.from("1"));
         tp1.sendEventOrdered(Buffer.from("3"));
         tp1.sendEvent(Buffer.from("2"));
 
-        
-
         expect(tp2.receiveMessage(tp1.send())).toEqual({
-            events: [
-                Buffer.from("1"), 
-                Buffer.from("2"), 
-            ],
-            eventsOrdered: [
-                Buffer.from("3")
-            ]
+            events: [Buffer.from("1"), Buffer.from("2")],
+            eventsOrdered: [Buffer.from("3")],
         });
     });
 
     test("RPC execution", () => {
-        expect(tp1.callFn("add", Buffer.from("12345"))).toEqual(1)
-        expect(tp1.callFn("sum")).toEqual(2)
-        expect(tp1.callFnOrdered("sum", Buffer.from("12345"))).toEqual(3)
-        expect(tp1.callFnOrdered("add")).toEqual(4)
+        expect(tp1.callFn("add", Buffer.from("12345"))).toEqual(1);
+        expect(tp1.callFn("sum")).toEqual(2);
+        expect(tp1.callFnOrdered("sum", Buffer.from("12345"))).toEqual(3);
+        expect(tp1.callFnOrdered("add")).toEqual(4);
 
-        const incMsg = tp2.receiveMessage(tp1.send())
+        const incMsg = tp2.receiveMessage(tp1.send());
         expect(incMsg).toEqual({
             rpcCalls: [
-              {
-                id: 1,
-                method: "add",
-                args: Buffer.from("12345"),
-              },
-              {
-                id: 2,
-                method: "sum",
-              },
-              {
-                id: 3,
-                method: "sum",
-                args: Buffer.from("12345"),
-              },
-              {
-                id: 4,
-                method: "add",
-              },
+                {
+                    id: 1,
+                    method: "add",
+                    args: Buffer.from("12345"),
+                },
+                {
+                    id: 2,
+                    method: "sum",
+                },
+                {
+                    id: 3,
+                    method: "sum",
+                    args: Buffer.from("12345"),
+                },
+                {
+                    id: 4,
+                    method: "add",
+                },
             ],
-          })
-        incMsg.rpcCalls.map(({id, method, args}) => {
-            if (method === "add") tp2.sendFnCallResponse(id, Buffer.concat([Buffer.from([0, 0]), args || Buffer.allocUnsafe(0)]));
-            if (method === "sum") tp2.sendFnCallResponse(id, Buffer.concat([Buffer.from([0, 0]), args || Buffer.allocUnsafe(0)]));
-        })
-        const tmp = tp1.receiveMessage(tp2.send())
+        });
+        incMsg.rpcCalls.map(({ id, method, args }) => {
+            if (method === "add")
+                tp2.sendFnCallResponse(id, Buffer.concat([Buffer.from([0, 0]), args || Buffer.allocUnsafe(0)]));
+            if (method === "sum")
+                tp2.sendFnCallResponse(id, Buffer.concat([Buffer.from([0, 0]), args || Buffer.allocUnsafe(0)]));
+        });
+        const tmp = tp1.receiveMessage(tp2.send());
         expect(tmp).toEqual({
             rpcResults: [
-              {
-                method: "add",
-                args: Buffer.from("12345"),
-                id: 1,
-                result: {
-                  returns: Buffer.concat([Buffer.alloc(2), Buffer.from("12345")]),
+                {
+                    method: "add",
+                    args: Buffer.from("12345"),
+                    id: 1,
+                    result: {
+                        returns: Buffer.concat([Buffer.alloc(2), Buffer.from("12345")]),
+                    },
                 },
-              },
-              {
-                method: "sum",
-                id: 2,
-                result: {
-                  returns: Buffer.alloc(2),
+                {
+                    method: "sum",
+                    id: 2,
+                    result: {
+                        returns: Buffer.alloc(2),
+                    },
                 },
-              },
-              {
-                method: "sum",
-                args: Buffer.from("12345"),
-                id: 3,
-                result: {
-                  returns: Buffer.concat([Buffer.alloc(2), Buffer.from("12345")]),
+                {
+                    method: "sum",
+                    args: Buffer.from("12345"),
+                    id: 3,
+                    result: {
+                        returns: Buffer.concat([Buffer.alloc(2), Buffer.from("12345")]),
+                    },
                 },
-              },
-              {
-                method: "add",
-                id: 4,
-                result: {
-                  returns: Buffer.alloc(2),
+                {
+                    method: "add",
+                    id: 4,
+                    result: {
+                        returns: Buffer.alloc(2),
+                    },
                 },
-              },
             ],
-          })
+        });
     });
-
 
     test("Object Syncing", () => {
         tp1.outObj.int = 1234;
@@ -287,16 +277,16 @@ describe("LibTop roundtrip", () => {
             str: "test",
             bytes: Buffer.from("12345"),
             naprej: {
-              boolean: false,
-              naprej: {
-                float: 3.14,
-              },
+                boolean: false,
+                naprej: {
+                    float: 3.14,
+                },
             },
-          }
+        };
 
-        tp1.outObj = testObj
+        tp1.outObj = testObj;
         const msg = tp2.receiveMessage(tp1.send());
-        
+
         expect(msg.objAll.int).toEqual(1234);
         expect(msg.objAll.naprej.naprej.float).toBeCloseTo(3.14, 3);
         expect(msg.objAll.bytes).toEqual(Buffer.from("12345"));
@@ -315,7 +305,6 @@ describe("LibTop roundtrip", () => {
         expect(tp2.incObj.naprej.boolean).toEqual(false);
         expect(tp2.incObj.str).toEqual("test");
     });
-        
 
     test("Object Syncing with preset", () => {
         tp1 = new LibTop({
@@ -344,7 +333,7 @@ describe("LibTop roundtrip", () => {
         tp1.outObj.bytes = Buffer.from("12345");
         delete tp1.outObj.str;
 
-        const msg = tp2.receiveMessage(tp1.send());
+        tp2.receiveMessage(tp1.send());
 
         expect(tp2.incObj.int).toEqual(1234);
         expect(tp2.incObj.naprej.naprej.float).toBeCloseTo(3.14, 3);

--- a/src/__tests__/serializer.test.ts
+++ b/src/__tests__/serializer.test.ts
@@ -1,0 +1,80 @@
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
+import { stringify, parse } from "../serializer";
+
+const test1 = {
+    a: 1,
+    b: "asd",
+    c: {
+        a: 2,
+        b: "asd",
+        c: {
+            test: 123,
+        },
+        d: {
+            a: 2,
+            b: "uhg",
+            c: {
+                a: true,
+            },
+        },
+        e: false,
+    },
+    d: {
+        a: 2,
+        b: "dfg",
+        c: {
+            test: 123,
+        },
+    },
+    e: "asdfg",
+};
+
+const test2 = {
+    buf: Buffer.from("1234"),
+    a: 123,
+    b: "str",
+    c: {
+        c: {
+            bool: true,
+            buf: Buffer.from("1234")
+        }
+    },
+    m: new Map([
+        [1, {a: "123"}],
+        [2, {b: Buffer.from("12")}],
+        [3, {a: "neki", b: Buffer.from("1234")}],
+    ]),
+    mm: new Map([
+        [1, Buffer.from("1")],
+        [2, Buffer.allocUnsafe(0)],
+        [3, Buffer.from("123141413453453452345345")]
+    ])
+}
+
+const test3 = {
+    a: test1,
+    b: test2,
+    m1: new Map([
+        [1, test1],
+        [2, test1],
+        [3, test1]
+    ]),
+    m2: new Map([
+        [1, test2],
+        [2, test2],
+        [3, test2]
+    ])
+}
+
+describe("Test serializer", () => {
+    test("Simple object", () => {
+        expect(parse(stringify(test1))).toEqual(test1)
+    })
+
+    test("Maps and Buffers", () => {
+        expect(parse(stringify(test2))).toEqual(test2)
+    })
+    test("Complex combined object", () => {
+        expect(parse(stringify(test3))).toEqual(test3)
+    })
+});

--- a/src/__tests__/serializer.test.ts
+++ b/src/__tests__/serializer.test.ts
@@ -36,20 +36,20 @@ const test2 = {
     c: {
         c: {
             bool: true,
-            buf: Buffer.from("1234")
-        }
+            buf: Buffer.from("1234"),
+        },
     },
     m: new Map([
-        [1, {a: "123"}],
-        [2, {b: Buffer.from("12")}],
-        [3, {a: "neki", b: Buffer.from("1234")}],
+        [1, { a: "123" }],
+        [2, { b: Buffer.from("12") }],
+        [3, { a: "neki", b: Buffer.from("1234") }],
     ]),
     mm: new Map([
         [1, Buffer.from("1")],
         [2, Buffer.allocUnsafe(0)],
-        [3, Buffer.from("123141413453453452345345")]
-    ])
-}
+        [3, Buffer.from("123141413453453452345345")],
+    ]),
+};
 
 const test3 = {
     a: test1,
@@ -57,24 +57,24 @@ const test3 = {
     m1: new Map([
         [1, test1],
         [2, test1],
-        [3, test1]
+        [3, test1],
     ]),
     m2: new Map([
         [1, test2],
         [2, test2],
-        [3, test2]
-    ])
-}
+        [3, test2],
+    ]),
+};
 
 describe("Test serializer", () => {
     test("Simple object", () => {
-        expect(parse(stringify(test1))).toEqual(test1)
-    })
+        expect(parse(stringify(test1))).toEqual(test1);
+    });
 
     test("Maps and Buffers", () => {
-        expect(parse(stringify(test2))).toEqual(test2)
-    })
+        expect(parse(stringify(test2))).toEqual(test2);
+    });
     test("Complex combined object", () => {
-        expect(parse(stringify(test3))).toEqual(test3)
-    })
+        expect(parse(stringify(test3))).toEqual(test3);
+    });
 });

--- a/src/differ.ts
+++ b/src/differ.ts
@@ -38,10 +38,11 @@ export function getSync(oldObj: Record<string, any> = {}, newObj: Record<string,
 
 export function getDelete(oldObj: Record<string, any>, newObj: Record<string, any>): Record<string, any> {
     return transform(oldObj, (acc, value, key) => {
-        if (!newObj[key]) {
+        if (!newObj.hasOwnProperty(key)) {
             acc[key] = true;
         } else if (isPlainObject(value)) {
-            acc[key] = getDelete(value, newObj[key]);
+            const del = getDelete(value, newObj[key])
+            if (Object.keys(del).length > 0) acc[key] = del
         }
     });
 }

--- a/src/differ.ts
+++ b/src/differ.ts
@@ -38,11 +38,11 @@ export function getSync(oldObj: Record<string, any> = {}, newObj: Record<string,
 
 export function getDelete(oldObj: Record<string, any>, newObj: Record<string, any>): Record<string, any> {
     return transform(oldObj, (acc, value, key) => {
-        if (!newObj.hasOwnProperty(key)) {
+        if (!Object.prototype.hasOwnProperty.call(newObj, key)) {
             acc[key] = true;
         } else if (isPlainObject(value)) {
-            const del = getDelete(value, newObj[key])
-            if (Object.keys(del).length > 0) acc[key] = del
+            const del = getDelete(value, newObj[key]);
+            if (Object.keys(del).length > 0) acc[key] = del;
         }
     });
 }

--- a/src/idCreator.ts
+++ b/src/idCreator.ts
@@ -1,22 +1,22 @@
 export default class IdCreator {
-    min: number;
+    readonly min: number;
 
-    max: number;
+    readonly max: number;
 
-    curId: number;
+    cur: number;
 
-    constructor(min = 1, max = 65535) {
+    constructor(cur = 1, min = 1, max = 65535) {
         this.min = min;
         this.max = max;
-        this.curId = min;
+        this.cur = cur;
     }
 
     next() {
-        const id = this.curId;
+        const id = this.cur;
         if (id >= this.max) {
-            this.curId = this.min;
+            this.cur = this.min;
         } else {
-            this.curId++;
+            this.cur++;
         }
         return id;
     }

--- a/src/libTop.ts
+++ b/src/libTop.ts
@@ -53,9 +53,8 @@ interface FnCall {
     id: number;
     args?: Buffer;
     method: string;
-    resolve: Function;
-    reject: Function;
     sent: boolean;
+    result?: RpcResObj;
 }
 
 function removeUndefinedAndEmpty(o: Record<string, any>) {
@@ -157,11 +156,7 @@ export default class LibTop extends EventEmitter {
                 return;
             }
 
-            if (returnsObj.isError === true) {
-                callObj.reject(returnsObj.returns || Buffer.allocUnsafe(0));
-            } else {
-                callObj.resolve(returnsObj.returns || Buffer.allocUnsafe(0));
-            }
+            callObj.result = returnsObj;
 
             this.requests.delete(id);
             this.requestsOrdered.delete(id);
@@ -237,36 +232,30 @@ export default class LibTop extends EventEmitter {
         }
     }
 
-    callFn(method: string, args?: Buffer): Promise<Buffer> {
+    callFn(method: string, args?: Buffer): number {
         const id = this.idCreator.next();
-        // console.log(`top fn called id:${id}`)
 
-        return new Promise((resolve, reject) => {
-            this.requests.set(id, {
-                method,
-                args,
-                resolve,
-                reject,
-                id,
-                sent: false,
-            });
+        this.requests.set(id, {
+            method,
+            args,
+            id,
+            sent: false,
         });
+
+        return id;
     }
 
-    callFnOrdered(method: string, args?: Buffer): Promise<Buffer> {
+    callFnOrdered(method: string, args?: Buffer): number {
         const id = this.idCreator.next();
-        // console.log(`top fn called id:${id}`)
 
-        return new Promise((resolve, reject) => {
             this.requestsOrdered.set(id, {
                 method,
                 args,
-                resolve,
-                reject,
                 id,
                 sent: false,
             });
-        });
+        
+        return id;
     }
 
     /**

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -1,0 +1,37 @@
+/**
+ * Serializes any object using custom Map and Buffer encoding
+ * @param object Object to be serialized
+ * @returns Serialized object
+ */
+export function stringify(object: Record<string, any>): string {
+    return JSON.stringify(object, (key, value) => {
+        if(value instanceof Map) {
+            return {
+                mapValue: [...value],
+            };
+        }
+        if(value.type === "Buffer" && Array.isArray(value.data)){
+            return { bufBase64: Buffer.from(value.data).toString("base64") };
+        }
+        return value
+    })
+}
+ 
+/**
+ * Deserializes a string according to the custom encoding
+ * @param str String to deserialize
+ * @returns Deserialized object
+ */
+export function parse(str: string): Record<string, any> {
+    return JSON.parse(str, (key, value) => {
+        if (typeof value === 'object' && value !== null) {
+            if (Array.isArray(value.mapValue) && Object.keys(value).length === 1) {
+                return new Map(value.mapValue);
+            }
+            if (typeof value.bufBase64 === "string" && Object.keys(value).length === 1){
+                return Buffer.from(value.bufBase64, "base64");
+            }
+        }
+        return value;
+    })
+}

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -5,18 +5,18 @@
  */
 export function stringify(object: Record<string, any>): string {
     return JSON.stringify(object, (key, value) => {
-        if(value instanceof Map) {
+        if (value instanceof Map) {
             return {
                 mapValue: [...value],
             };
         }
-        if(value.type === "Buffer" && Array.isArray(value.data)){
+        if (value && value.type === "Buffer" && Array.isArray(value.data)) {
             return { bufBase64: Buffer.from(value.data).toString("base64") };
         }
-        return value
-    })
+        return value;
+    });
 }
- 
+
 /**
  * Deserializes a string according to the custom encoding
  * @param str String to deserialize
@@ -24,14 +24,14 @@ export function stringify(object: Record<string, any>): string {
  */
 export function parse(str: string): Record<string, any> {
     return JSON.parse(str, (key, value) => {
-        if (typeof value === 'object' && value !== null) {
+        if (typeof value === "object" && value !== null) {
             if (Array.isArray(value.mapValue) && Object.keys(value).length === 1) {
                 return new Map(value.mapValue);
             }
-            if (typeof value.bufBase64 === "string" && Object.keys(value).length === 1){
+            if (typeof value.bufBase64 === "string" && Object.keys(value).length === 1) {
                 return Buffer.from(value.bufBase64, "base64");
             }
         }
         return value;
-    })
+    });
 }


### PR DESCRIPTION
An event emitter is now only used in the Protocol class. LibBot and LibTop now work synchronously.

LibBot and LibTop can now be serialized and deserialized, opening options for storage in stateless environments.